### PR TITLE
Update the way checking is done for ini_set

### DIFF
--- a/library/Zend/Validate/StringLength.php
+++ b/library/Zend/Validate/StringLength.php
@@ -205,7 +205,8 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
             if (PHP_VERSION_ID < 50600) {
                 $result = iconv_set_encoding('internal_encoding', $encoding);
             } else {
-                $result = ini_set('default_charset', $encoding);
+                ini_set('default_charset', $encoding);
+                $result = ini_get('default_charset');
             }
             if (!$result) {
                 require_once 'Zend/Validate/Exception.php';


### PR DESCRIPTION
ini_set returns the previous value so if the previous value is "" the exception will always spark. This fix will patch that.
